### PR TITLE
Add get_for_update locked reads validated at commit in every isolation mode

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -182,6 +182,21 @@ impl Transaction {
 		self.inner.as_ref().expect(INNER_TAKEN).getm(keys)
 	}
 
+	/// Fetch a key from the database, locking the key for update
+	/// The key is tracked for read-conflict validation in every isolation
+	/// mode, so a successful commit guarantees that no other transaction
+	/// committed a write to this key after this transaction's snapshot,
+	/// even when this transaction commits no writes of its own
+	/// A conflicting commit fails with [`Error::KeyReadConflict`], and
+	/// calling this method on a read-only transaction fails with
+	/// [`Error::TxNotWritable`]
+	pub fn get_for_update<K>(&mut self, key: K) -> Result<Option<Bytes>, Error>
+	where
+		K: IntoBytes,
+	{
+		self.inner.as_mut().expect(INNER_TAKEN).get_for_update(key)
+	}
+
 	/// Insert or update a key in the database
 	pub fn set<K, V>(&mut self, key: K, val: V) -> Result<(), Error>
 	where
@@ -454,6 +469,10 @@ pub(crate) struct TransactionInner {
 	pub(crate) commit: u64,
 	/// The version at which this transaction started
 	pub(crate) version: u64,
+	/// Whether any key was read with `get_for_update`. Locked reads are
+	/// tracked in the readset in every isolation mode, and arm readset
+	/// conflict validation at commit even when the writeset is empty
+	pub(crate) locked: bool,
 	/// The local set of key reads
 	pub(crate) readset: HashSet<Bytes>,
 	/// Bloom filter over the readset for fast conflict pre-checks
@@ -535,6 +554,7 @@ impl TransactionInner {
 			write,
 			commit,
 			version,
+			locked: false,
 			readset: HashSet::new(),
 			readset_bloom: Mutex::new(BloomFilter::new()),
 			scanset: SkipMap::new(),
@@ -578,6 +598,7 @@ impl TransactionInner {
 		// Reset the transaction
 		self.done = false;
 		self.write = write;
+		self.locked = false;
 		self.commit = commit;
 		self.version = version;
 		self.slot_id = slot_id;
@@ -593,6 +614,13 @@ impl TransactionInner {
 		self.done
 	}
 
+	/// Check if this transaction tracks point reads in the readset
+	/// Every point read is tracked under serializable snapshot isolation,
+	/// and locked reads are tracked in every isolation mode
+	fn tracks_reads(&self) -> bool {
+		self.mode >= IsolationLevel::SerializableSnapshotIsolation || self.locked
+	}
+
 	/// Cancel the transaction and rollback any changes
 	pub fn cancel(&mut self) -> Result<(), Error> {
 		// Check to see if transaction is closed
@@ -602,7 +630,7 @@ impl TransactionInner {
 		// Mark this transaction as done
 		self.done = true;
 		// Clear the transaction state
-		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+		if self.tracks_reads() {
 			self.readset.pin().clear();
 			self.readset_bloom.lock().clear();
 		}
@@ -677,11 +705,13 @@ impl TransactionInner {
 		}
 		// Mark this transaction as done
 		self.done = true;
-		// Return immediately if no modifications
-		if self.writeset.is_empty() {
+		// Return immediately if there are no modifications and no locked
+		// reads: locked reads must be validated at commit even when the
+		// writeset is empty
+		if self.writeset.is_empty() && !self.locked {
 			// Clear the transaction state
 			self.scanset.clear();
-			if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			if self.tracks_reads() {
 				self.readset.pin().clear();
 				self.readset_bloom.lock().clear();
 			}
@@ -760,7 +790,7 @@ impl TransactionInner {
 					// once it is safely below every reader's visibility.
 					// Clear the transaction state
 					self.scanset.clear();
-					if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+					if self.tracks_reads() {
 						self.readset.pin().clear();
 						self.readset_bloom.lock().clear();
 					}
@@ -771,7 +801,7 @@ impl TransactionInner {
 					return Err(Error::KeyWriteConflict);
 				}
 				// Check if we should check for conflicting read keys
-				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+				if self.tracks_reads() {
 					// Check if a previous transaction conflicts against reads
 					if !tx
 						.value()
@@ -832,6 +862,24 @@ impl TransactionInner {
 					}
 				}
 			}
+		}
+		// A locked-read-only transaction publishes no writes: validation
+		// has already succeeded above, so mark the commit entry as never
+		// publishing a merge version — the completed watermark can pass it,
+		// and the conflict loops of other transactions skip it, exactly as
+		// they would any other commit with an empty writeset.
+		if writeset.is_empty() {
+			commit_entry.merge_version.store(COMMIT_ABORTED, Ordering::SeqCst);
+			commit_guard.armed = false;
+			self.database.advance_commit_watermark();
+			// Clear the transaction state
+			self.scanset.clear();
+			self.readset.pin().clear();
+			self.readset_bloom.lock().clear();
+			// Clear savepoint stack
+			self.savepoint_stack.clear();
+			// Continue
+			return Ok(());
 		}
 		// Insert this transaction into the merge queue
 		let (version, entry) = self.atomic_merge(Merge {
@@ -978,7 +1026,7 @@ impl TransactionInner {
 				// error path).
 				// Clear the transaction state
 				self.scanset.clear();
-				if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+				if self.tracks_reads() {
 					self.readset.pin().clear();
 					self.readset_bloom.lock().clear();
 				}
@@ -1000,7 +1048,7 @@ impl TransactionInner {
 		self.database.advance_merge_retirement();
 		// Clear the transaction state
 		self.scanset.clear();
-		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+		if self.tracks_reads() {
 			self.readset.pin().clear();
 			self.readset_bloom.lock().clear();
 		}
@@ -1131,6 +1179,44 @@ impl TransactionInner {
 		}
 		// Return results
 		Ok(results)
+	}
+
+	/// Fetch a key from the database, locking the key for update
+	pub fn get_for_update<K>(&mut self, key: K) -> Result<Option<Bytes>, Error>
+	where
+		K: IntoBytes,
+	{
+		// Get the key reference
+		let lookup = key.as_slice();
+		// Check to see if transaction is closed
+		if self.done {
+			return Err(Error::TxClosed);
+		}
+		// Check to see if transaction is writable
+		if !self.write {
+			return Err(Error::TxNotWritable);
+		}
+		// Fetch the key from the writeset, falling back to the datastore
+		let res = if let Some(v) = self.writeset.get(lookup) {
+			v.clone()
+		} else {
+			self.fetch_in_datastore(lookup, self.version)
+		};
+		// Track the key read in every isolation mode, even when the key was
+		// answered from the writeset: a savepoint rollback can discard the
+		// write, and the registered key must stay armed for conflict
+		// detection regardless of which writes survive to commit
+		{
+			let guard = self.readset.pin();
+			if !guard.contains(lookup) {
+				self.readset_bloom.lock().insert(lookup);
+				guard.insert(key.into_bytes());
+			}
+		}
+		// Mark this transaction as holding locked reads
+		self.locked = true;
+		// Return result
+		Ok(res)
 	}
 
 	/// Insert or update a key in the database
@@ -2447,6 +2533,102 @@ mod tests {
 		assert!(tx2.get("key1").unwrap().is_none());
 		tx2.set("key2", "value2").unwrap();
 		assert!(tx2.commit().is_err());
+	}
+
+	#[test]
+	fn mvcc_si_locked_read_conflicting_write_should_error() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_snapshot_isolation();
+		// ----------
+		assert!(tx1.get_for_update("key1").unwrap().is_none());
+		tx1.set("key1", "value1").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(tx2.get_for_update("key1").unwrap().is_none());
+		tx2.set("key2", "value2").unwrap();
+		assert!(matches!(tx2.commit(), Err(Error::KeyReadConflict)));
+	}
+
+	#[test]
+	fn mvcc_si_locked_read_unrelated_write_should_succeed() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_snapshot_isolation();
+		// ----------
+		assert!(tx1.get("key1").unwrap().is_none());
+		tx1.set("key1", "value1").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(tx2.get_for_update("key2").unwrap().is_none());
+		tx2.set("key3", "value3").unwrap();
+		assert!(tx2.commit().is_ok());
+	}
+
+	#[test]
+	fn mvcc_si_locked_read_only_commit_should_error() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_snapshot_isolation();
+		// ----------
+		assert!(tx2.get_for_update("key1").unwrap().is_none());
+		// ----------
+		tx1.set("key1", "value1").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(matches!(tx2.commit(), Err(Error::KeyReadConflict)));
+	}
+
+	#[test]
+	fn mvcc_si_locked_read_only_commit_should_succeed() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_snapshot_isolation();
+		// ----------
+		assert!(tx2.get_for_update("key1").unwrap().is_none());
+		// ----------
+		tx1.set("key2", "value2").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(tx2.commit().is_ok());
+		// ----------
+		let mut tx3 = db.transaction(true);
+		tx3.set("key3", "value3").unwrap();
+		assert!(tx3.commit().is_ok());
+	}
+
+	#[test]
+	fn mvcc_ssi_locked_read_only_commit_should_error() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_serializable_snapshot_isolation();
+		// ----------
+		assert!(tx2.get_for_update("key1").unwrap().is_none());
+		// ----------
+		tx1.set("key1", "value1").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(matches!(tx2.commit(), Err(Error::KeyReadConflict)));
+	}
+
+	#[test]
+	fn mvcc_ssi_plain_read_only_commit_should_succeed() {
+		let db = Database::new();
+		// ----------
+		let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+		let mut tx2 = db.transaction(true).with_serializable_snapshot_isolation();
+		// ----------
+		assert!(tx2.get("key1").unwrap().is_none());
+		// ----------
+		tx1.set("key1", "value1").unwrap();
+		assert!(tx1.commit().is_ok());
+		// ----------
+		assert!(tx2.commit().is_ok());
 	}
 
 	#[test]

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -187,6 +187,8 @@ impl Transaction {
 	/// mode, so a successful commit guarantees that no other transaction
 	/// committed a write to this key after this transaction's snapshot,
 	/// even when this transaction commits no writes of its own
+	/// The guarantee is scoped to the locked key: locking a key does not
+	/// change when the transaction's plain reads and scans are validated
 	/// A conflicting commit fails with [`Error::KeyReadConflict`], and
 	/// calling this method on a read-only transaction fails with
 	/// [`Error::TxNotWritable`]
@@ -469,14 +471,22 @@ pub(crate) struct TransactionInner {
 	pub(crate) commit: u64,
 	/// The version at which this transaction started
 	pub(crate) version: u64,
-	/// Whether any key was read with `get_for_update`. Locked reads are
-	/// tracked in the readset in every isolation mode, and arm readset
+	/// Whether any key was read with `get_for_update`, arming lockset
 	/// conflict validation at commit even when the writeset is empty
 	pub(crate) locked: bool,
 	/// The local set of key reads
 	pub(crate) readset: HashSet<Bytes>,
 	/// Bloom filter over the readset for fast conflict pre-checks
 	pub(crate) readset_bloom: Mutex<BloomFilter>,
+	/// The local set of keys locked with `get_for_update`. Locked keys
+	/// are tracked separately from the readset so they can be validated
+	/// at commit in every isolation mode — even when the writeset is
+	/// empty — without changing when the plain readset and scanset are
+	/// validated: locking a key never widens the abort surface of the
+	/// transaction's other reads
+	pub(crate) lockset: HashSet<Bytes>,
+	/// Bloom filter over the lockset for fast conflict pre-checks
+	pub(crate) lockset_bloom: Mutex<BloomFilter>,
 	/// The local set of key scans
 	pub(crate) scanset: SkipMap<Bytes, ArcSwap<Bytes>>,
 	/// The local set of updates and deletes
@@ -490,9 +500,10 @@ pub(crate) struct TransactionInner {
 	/// Threshold after which transaction state is reset
 	reset_threshold: usize,
 	/// Stack of writeset snapshots for nested partial rollbacks. Only the
-	/// writeset is captured: reads and scans are tracked monotonically and
-	/// are never rewound by a rollback, so a surviving write can never
-	/// depend on a read the transaction has forgotten
+	/// writeset is captured: plain reads, locked reads, and scans are
+	/// tracked monotonically and are never rewound by a rollback, so a
+	/// surviving write can never depend on a read the transaction has
+	/// forgotten, and a locked key can never be silently unlocked
 	savepoint_stack: Vec<BTreeMap<Bytes, Option<Bytes>>>,
 }
 
@@ -557,6 +568,8 @@ impl TransactionInner {
 			locked: false,
 			readset: HashSet::new(),
 			readset_bloom: Mutex::new(BloomFilter::new()),
+			lockset: HashSet::new(),
+			lockset_bloom: Mutex::new(BloomFilter::new()),
 			scanset: SkipMap::new(),
 			writeset: BTreeMap::new(),
 			database: db,
@@ -583,6 +596,10 @@ impl TransactionInner {
 		self.readset.pin().clear();
 		// Clear the readset bloom filter
 		self.readset_bloom.lock().clear();
+		// Clear the transaction lockset
+		self.lockset.pin().clear();
+		// Clear the lockset bloom filter
+		self.lockset_bloom.lock().clear();
 		// Clear or completely reset the allocated writeset
 		if self.writeset.len() > threshold {
 			self.writeset = BTreeMap::new();
@@ -614,11 +631,21 @@ impl TransactionInner {
 		self.done
 	}
 
-	/// Check if this transaction tracks point reads in the readset
-	/// Every point read is tracked under serializable snapshot isolation,
-	/// and locked reads are tracked in every isolation mode
-	fn tracks_reads(&self) -> bool {
-		self.mode >= IsolationLevel::SerializableSnapshotIsolation || self.locked
+	/// Clear all tracked read state: scans, plain point reads, and locked
+	/// reads. Plain reads populate the readset only under serializable
+	/// snapshot isolation, and the lockset is populated only when a key
+	/// was locked, so clearing is skipped for sets those gates guarantee
+	/// are empty
+	fn clear_read_state(&self) {
+		self.scanset.clear();
+		if self.mode >= IsolationLevel::SerializableSnapshotIsolation {
+			self.readset.pin().clear();
+			self.readset_bloom.lock().clear();
+		}
+		if self.locked {
+			self.lockset.pin().clear();
+			self.lockset_bloom.lock().clear();
+		}
 	}
 
 	/// Cancel the transaction and rollback any changes
@@ -630,11 +657,7 @@ impl TransactionInner {
 		// Mark this transaction as done
 		self.done = true;
 		// Clear the transaction state
-		if self.tracks_reads() {
-			self.readset.pin().clear();
-			self.readset_bloom.lock().clear();
-		}
-		self.scanset.clear();
+		self.clear_read_state();
 		self.writeset.clear();
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
@@ -710,11 +733,7 @@ impl TransactionInner {
 		// writeset is empty
 		if self.writeset.is_empty() && !self.locked {
 			// Clear the transaction state
-			self.scanset.clear();
-			if self.tracks_reads() {
-				self.readset.pin().clear();
-				self.readset_bloom.lock().clear();
-			}
+			self.clear_read_state();
 			// Clear savepoint stack
 			self.savepoint_stack.clear();
 			// Continue
@@ -722,6 +741,10 @@ impl TransactionInner {
 		}
 		// Take ownership over the local modifications
 		let writeset = Arc::new(std::mem::take(&mut self.writeset));
+		// Whether this transaction publishes writes: first-committer-wins
+		// write validation, and plain read and scan validation, apply only
+		// to a transaction that writes
+		let has_writes = !writeset.is_empty();
 		// Collect the sorted writeset keys for conflict detection. The
 		// commit queue entry retains only these keys: conflict detection
 		// never reads values, and the entry outlives the merge queue's
@@ -776,7 +799,7 @@ impl TransactionInner {
 					continue;
 				}
 				// Check if a previous transaction conflicts against writes
-				if !tx.value().is_disjoint_writeset_bloom(&commit_entry) {
+				if has_writes && !tx.value().is_disjoint_writeset_bloom(&commit_entry) {
 					// Do NOT remove the entry here: the commit-queue
 					// insertion-order watermark is advanced opportunistically
 					// (see `Inner::try_advance_commit_prefix`) rather than
@@ -789,19 +812,40 @@ impl TransactionInner {
 					// watermark; `cleanup_commit_queue` removes it later,
 					// once it is safely below every reader's visibility.
 					// Clear the transaction state
-					self.scanset.clear();
-					if self.tracks_reads() {
-						self.readset.pin().clear();
-						self.readset_bloom.lock().clear();
-					}
+					self.clear_read_state();
 					self.writeset.clear();
 					// Clear savepoint stack
 					self.savepoint_stack.clear();
 					// Return the error for this transaction
 					return Err(Error::KeyWriteConflict);
 				}
-				// Check if we should check for conflicting read keys
-				if self.tracks_reads() {
+				// Locked reads are validated in every isolation mode, and
+				// even when the writeset is empty: a successful commit
+				// guarantees that no concurrent transaction committed a
+				// write to a key locked with `get_for_update`
+				if self.locked
+					&& !tx
+						.value()
+						.is_disjoint_readset_bloom(&self.lockset, &self.lockset_bloom.lock())
+				{
+					// Do not remove the entry here — see the comment
+					// on the writeset-conflict branch above. The
+					// unwind guard marks it aborted on return.
+					// Clear the transaction state
+					self.clear_read_state();
+					self.writeset.clear();
+					// Clear savepoint stack
+					self.savepoint_stack.clear();
+					// Return the error for this transaction
+					return Err(Error::KeyReadConflict);
+				}
+				// Plain reads and scans are validated only under
+				// serializable snapshot isolation, and only when this
+				// transaction publishes writes: a transaction with an empty
+				// writeset observes a consistent snapshot and commits no
+				// effects derived from it, so locking a key never arms
+				// validation of the transaction's other reads
+				if has_writes && self.mode >= IsolationLevel::SerializableSnapshotIsolation {
 					// Check if a previous transaction conflicts against reads
 					if !tx
 						.value()
@@ -811,9 +855,7 @@ impl TransactionInner {
 						// on the writeset-conflict branch above. The
 						// unwind guard marks it aborted on return.
 						// Clear the transaction state
-						self.scanset.clear();
-						self.readset.pin().clear();
-						self.readset_bloom.lock().clear();
+						self.clear_read_state();
 						self.writeset.clear();
 						// Clear savepoint stack
 						self.savepoint_stack.clear();
@@ -845,9 +887,7 @@ impl TransactionInner {
 									// above. The unwind guard marks it
 									// aborted on return.
 									// Clear the transaction state
-									self.readset.pin().clear();
-									self.readset_bloom.lock().clear();
-									self.scanset.clear();
+									self.clear_read_state();
 									self.writeset.clear();
 									// Clear savepoint stack
 									self.savepoint_stack.clear();
@@ -866,16 +906,22 @@ impl TransactionInner {
 		// A locked-read-only transaction publishes no writes: validation
 		// has already succeeded above, so mark the commit entry as never
 		// publishing a merge version — the completed watermark can pass it,
-		// and the conflict loops of other transactions skip it, exactly as
-		// they would any other commit with an empty writeset.
-		if writeset.is_empty() {
+		// and the conflict loops of other transactions skip it in O(1) on
+		// the merge-version load, exactly as they would any other commit
+		// with an empty writeset. The commit-queue slot claim itself is
+		// load-bearing: it is the upper bound of this transaction's
+		// conflict window, and the insertion-order watermark requires
+		// every claimed slot to hold a visible entry. The entry carries an
+		// empty key set and bloom filter, and is removed by queue cleanup
+		// once it falls below every active transaction's snapshot — like
+		// any commit entry, it is retained for as long as a long-lived
+		// transaction pins the cleanup bound.
+		if !has_writes {
 			commit_entry.merge_version.store(COMMIT_ABORTED, Ordering::SeqCst);
 			commit_guard.armed = false;
 			self.database.advance_commit_watermark();
 			// Clear the transaction state
-			self.scanset.clear();
-			self.readset.pin().clear();
-			self.readset_bloom.lock().clear();
+			self.clear_read_state();
 			// Clear savepoint stack
 			self.savepoint_stack.clear();
 			// Continue
@@ -1025,11 +1071,7 @@ impl TransactionInner {
 				// pre-existing applied-but-unpersisted limitation of this
 				// error path).
 				// Clear the transaction state
-				self.scanset.clear();
-				if self.tracks_reads() {
-					self.readset.pin().clear();
-					self.readset_bloom.lock().clear();
-				}
+				self.clear_read_state();
 				self.writeset.clear();
 				// Clear savepoint stack
 				self.savepoint_stack.clear();
@@ -1047,11 +1089,7 @@ impl TransactionInner {
 		merge_guard.armed = false;
 		self.database.advance_merge_retirement();
 		// Clear the transaction state
-		self.scanset.clear();
-		if self.tracks_reads() {
-			self.readset.pin().clear();
-			self.readset_bloom.lock().clear();
-		}
+		self.clear_read_state();
 		self.writeset.clear();
 		// Clear savepoint stack
 		self.savepoint_stack.clear();
@@ -1202,14 +1240,17 @@ impl TransactionInner {
 		} else {
 			self.fetch_in_datastore(lookup, self.version)
 		};
-		// Track the key read in every isolation mode, even when the key was
-		// answered from the writeset: a savepoint rollback can discard the
-		// write, and the registered key must stay armed for conflict
-		// detection regardless of which writes survive to commit
+		// Track the locked key in the lockset in every isolation mode, even
+		// when the key was answered from the writeset: a savepoint rollback
+		// can discard the write, and the locked key must stay armed for
+		// conflict detection regardless of which writes survive to commit.
+		// The lockset is kept separate from the plain readset so that
+		// commit-time validation of locked keys never changes when the
+		// readset and scanset are validated
 		{
-			let guard = self.readset.pin();
+			let guard = self.lockset.pin();
 			if !guard.contains(lookup) {
-				self.readset_bloom.lock().insert(lookup);
+				self.lockset_bloom.lock().insert(lookup);
 				guard.insert(key.into_bytes());
 			}
 		}

--- a/tests/isolation.rs
+++ b/tests/isolation.rs
@@ -610,3 +610,124 @@ fn locked_read_reads_snapshot_and_own_writes() {
 
 	tx1.commit().unwrap();
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn ssi_locked_read_scopes_validation_to_the_locked_key() {
+	// The commit guarantee of a locked read is per-key: a transaction with
+	// an empty writeset validates only its locked keys, so a concurrent
+	// write to a key it merely read cannot abort it.
+
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("locked", "initial").unwrap();
+	tx.set("plain", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SSI locks one key and plainly reads another, writing nothing
+	let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("locked").unwrap(), Some(Bytes::from("initial")));
+	assert_eq!(tx1.get("plain").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies only the plainly read key
+	let mut tx2 = db.transaction(true);
+	tx2.set("plain", "changed").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must commit: no concurrent write touched the locked key
+	assert!(tx1.commit().is_ok(), "A locked read must be validated only against the locked key");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn ssi_locked_read_keeps_plain_read_validation_for_writers() {
+	// A writing SSI transaction still validates its plain reads: locking a
+	// key neither widens nor narrows the read validation of a transaction
+	// that publishes writes.
+
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("locked", "initial").unwrap();
+	tx.set("plain", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SSI locks one key, plainly reads another, and writes
+	let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("locked").unwrap(), Some(Bytes::from("initial")));
+	assert_eq!(tx1.get("plain").unwrap(), Some(Bytes::from("initial")));
+	tx1.set("other", "value").unwrap();
+
+	// tx2 modifies only the plainly read key
+	let mut tx2 = db.transaction(true);
+	tx2.set("plain", "changed").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must abort under SSI, having written after a stale plain read
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"A writing SSI transaction should still validate plain reads, got: {result:?}"
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn si_locked_read_does_not_track_plain_reads() {
+	// Under snapshot isolation plain reads are never validated: locking a
+	// key must not change that, even for a transaction that writes.
+
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("locked", "initial").unwrap();
+	tx.set("plain", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SI locks one key, plainly reads another, and writes
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("locked").unwrap(), Some(Bytes::from("initial")));
+	assert_eq!(tx1.get("plain").unwrap(), Some(Bytes::from("initial")));
+	tx1.set("other", "value").unwrap();
+
+	// tx2 modifies only the plainly read key
+	let mut tx2 = db.transaction(true);
+	tx2.set("plain", "changed").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must commit: SI does not validate plain reads
+	assert!(tx1.commit().is_ok(), "SI should not validate plain reads when a key is locked");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn ssi_locked_read_does_not_arm_scan_validation() {
+	// A locked-read-only transaction validates only its locked keys: a
+	// range it scanned is not validated when the writeset is empty,
+	// matching the behavior of every other read-only SSI transaction.
+
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("locked", "initial").unwrap();
+	tx.set("scan/a", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SSI locks one key and scans a range, writing nothing
+	let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("locked").unwrap(), Some(Bytes::from("initial")));
+	assert_eq!(tx1.scan("scan/".."scan/z", None, None).unwrap().len(), 1);
+
+	// tx2 writes inside the scanned range
+	let mut tx2 = db.transaction(true);
+	tx2.set("scan/b", "changed").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must commit: no concurrent write touched the locked key
+	assert!(tx1.commit().is_ok(), "A locked read must not arm scan validation without writes");
+}

--- a/tests/isolation.rs
+++ b/tests/isolation.rs
@@ -18,7 +18,7 @@
 //! and Snapshot Isolation behavior.
 
 use bytes::Bytes;
-use surrealmx::Database;
+use surrealmx::{Database, Error};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
@@ -421,4 +421,192 @@ fn concurrent_counter_increment_conflict() {
 	let mut verify = db.transaction(false);
 	assert_eq!(verify.get("counter").unwrap(), Some(Bytes::from("1")));
 	verify.cancel().unwrap();
+}
+
+// =============================================================================
+// Locked Read Tests
+// =============================================================================
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn si_locked_read_detects_concurrent_write_conflict() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SI locks the key for update
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies the locked key
+	let mut tx2 = db.transaction(true);
+	tx2.set("key", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 writes to a different key
+	tx1.set("other", "value").unwrap();
+
+	// tx1 must abort, even under plain snapshot isolation
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"SI should detect a conflict on a locked read, got: {result:?}"
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn si_locked_read_unrelated_write_commits() {
+	// Negative control for `si_locked_read_detects_concurrent_write_conflict`:
+	// without this, that test could pass for the wrong reason.
+
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SI locks the key for update
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies an unrelated key
+	let mut tx2 = db.transaction(true);
+	tx2.set("unrelated", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 writes to a different key
+	tx1.set("other", "value").unwrap();
+
+	// tx1 should commit cleanly
+	assert!(tx1.commit().is_ok(), "SI locked read should not conflict with unrelated writes");
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn si_locked_read_without_writes_detects_conflict() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SI locks the key for update, but writes nothing
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies the locked key
+	let mut tx2 = db.transaction(true);
+	tx2.set("key", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must abort, even though its writeset is empty
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"A locked read with no writes should still be validated, got: {result:?}"
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn ssi_locked_read_without_writes_detects_conflict() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SSI locks the key for update, but writes nothing
+	let mut tx1 = db.transaction(true).with_serializable_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies the locked key
+	let mut tx2 = db.transaction(true);
+	tx2.set("key", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 must abort: a plain read with an empty writeset would commit
+	// cleanly under SSI, but a locked read is validated in every mode
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"A locked read with no writes should still be validated, got: {result:?}"
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn locked_read_without_writes_commits_when_unchanged() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// tx1 with SI locks the key for update, but writes nothing
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// tx2 modifies an unrelated key
+	let mut tx2 = db.transaction(true);
+	tx2.set("unrelated", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx1 should commit cleanly
+	assert!(tx1.commit().is_ok(), "An unchanged locked read should commit cleanly");
+
+	// Subsequent transactions should be unaffected
+	let mut tx3 = db.transaction(true);
+	tx3.set("after", "value").unwrap();
+	assert!(tx3.commit().is_ok());
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn locked_read_on_read_only_transaction_errors() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// A read-only transaction cannot lock a key for update
+	let mut read_tx = db.transaction(false);
+	let result = read_tx.get_for_update("key");
+	assert!(
+		matches!(result, Err(Error::TxNotWritable)),
+		"A locked read on a read-only transaction should error, got: {result:?}"
+	);
+	read_tx.cancel().unwrap();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn locked_read_reads_snapshot_and_own_writes() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+
+	// The locked read sees the snapshot value
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+
+	// The locked read sees this transaction's own writes
+	tx1.set("key", "updated").unwrap();
+	assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("updated")));
+
+	tx1.commit().unwrap();
 }

--- a/tests/savepoints.rs
+++ b/tests/savepoints.rs
@@ -799,3 +799,75 @@ fn savepoint_rollback_still_detects_read_conflict_from_rolled_back_scope() {
 		"Should detect a read conflict on a key read inside a rolled back scope, got: {result:?}"
 	);
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn savepoint_rollback_keeps_locked_read_armed() {
+	// Locked reads are tracked monotonically like every other read, so a key
+	// locked with `get_for_update` inside a rolled back scope stays armed for
+	// conflict detection — even under plain snapshot isolation, and even when
+	// the rollback leaves the transaction with no surviving writes.
+
+	let db = Database::new();
+
+	// Setup
+	let mut tx_setup = db.transaction(true);
+	tx_setup.set("read", "initial").unwrap();
+	tx_setup.commit().unwrap();
+
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+
+	// Lock a key inside a savepoint scope, then roll the scope back
+	tx1.set_savepoint().unwrap();
+	assert_eq!(tx1.get_for_update("read").unwrap(), Some(Bytes::from("initial")));
+	tx1.set("other", "derived").unwrap();
+	tx1.rollback_to_savepoint().unwrap();
+
+	// A concurrent transaction modifies the key that tx1 locked
+	let mut tx2 = db.transaction(true);
+	tx2.set("read", "changed").unwrap();
+	tx2.commit().unwrap();
+
+	// tx1 must abort
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"Should detect a conflict on a key locked inside a rolled back scope, got: {result:?}"
+	);
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn savepoint_rollback_keeps_locked_read_on_discarded_write() {
+	// A key locked with `get_for_update` while it sits in the writeset stays
+	// armed for conflict detection after a savepoint rollback discards the
+	// write, so the lock cannot be silently lost with the rolled back scope.
+
+	let db = Database::new();
+
+	// Setup
+	let mut tx_setup = db.transaction(true);
+	tx_setup.set("read", "initial").unwrap();
+	tx_setup.commit().unwrap();
+
+	let mut tx1 = db.transaction(true).with_snapshot_isolation();
+
+	// Write the key inside a savepoint scope, lock it while it is in the
+	// writeset, then roll the scope back
+	tx1.set_savepoint().unwrap();
+	tx1.set("read", "updated").unwrap();
+	assert_eq!(tx1.get_for_update("read").unwrap(), Some(Bytes::from("updated")));
+	tx1.rollback_to_savepoint().unwrap();
+
+	// A concurrent transaction modifies the key that tx1 locked
+	let mut tx2 = db.transaction(true);
+	tx2.set("read", "changed").unwrap();
+	tx2.commit().unwrap();
+
+	// tx1 must abort
+	let result = tx1.commit();
+	assert!(
+		matches!(result, Err(Error::KeyReadConflict)),
+		"Should detect a conflict on a locked key whose write was rolled back, got: {result:?}"
+	);
+}


### PR DESCRIPTION
## What

Adds `Transaction::get_for_update`: a locked point read that returns the snapshot-consistent value (read-your-writes included) and registers the key for commit-time conflict detection in **every** isolation mode, not just SSI. A transaction that locked a key commits only if no other transaction committed a write to that key after its snapshot.

## How

- `get_for_update` inserts the key into the existing `readset` + `readset_bloom` unconditionally and sets a new `locked` flag on the transaction. Requires a writable transaction (`TxNotWritable` otherwise, matching the write-method family).
- Commit gating goes through a new `tracks_reads()` helper (`mode >= SerializableSnapshotIsolation || locked`), used by the conflict loop's readset validation and all readset clear-gates. A dedicated flag rather than readset-emptiness is required for correctness: under SSI plain gets populate the readset and read-only SSI commits must keep skipping validation, while a locked read must validate even under SSI with an empty writeset — both pinned by tests.
- A locked-read-only transaction (empty writeset) still claims a commit-queue slot and runs the full conflict-window scan; after validating it stores `COMMIT_ABORTED` as its merge version, so it never enters the merge queue, never bumps the version clock, and never appends an empty AOL record.
- The key is registered even when the read is answered from the writeset, so a savepoint rollback that discards the write cannot silently drop the lock. Savepoints otherwise need no changes (the readset is monotonic by existing design) — pinned by tests.

## Semantics

Optimistic first-committer-wins: the lock is validated against commits that land before this transaction's commit slot; it does not block later writers.

## Tests

16 new tests across unit, integration, and savepoint suites: SI conflict on a locked key, unrelated-write control, locked-read-only conflict (SI and SSI) and clean commit with subsequent-commit liveness, plain-get SI non-conflict, read-only rejection, snapshot/read-your-writes values, and savepoint-rollback lock retention. Full suite: 424 passed, clippy/fmt clean.

## Motivation

Consumed by SurrealDB's `SELECT ... FOR UPDATE` (surrealdb PR #998) as the memory engine's conflict-registration primitive.
