### PR TITLE
Keep the pooled transaction small by boxing its bloom filters

### DIFF
--- a/src/tx.rs
+++ b/src/tx.rs
@@ -476,8 +476,11 @@ pub(crate) struct TransactionInner {
 	pub(crate) locked: bool,
 	/// The local set of key reads
 	pub(crate) readset: HashSet<Bytes>,
-	/// Bloom filter over the readset for fast conflict pre-checks
-	pub(crate) readset_bloom: Mutex<BloomFilter>,
+	/// Bloom filter over the readset for fast conflict pre-checks. Boxed
+	/// so that the filter's bit array lives off the transaction struct:
+	/// pooled transactions are stored and returned by value, so every
+	/// byte here is copied on each pool checkout and release
+	pub(crate) readset_bloom: Mutex<Box<BloomFilter>>,
 	/// The local set of keys locked with `get_for_update`. Locked keys
 	/// are tracked separately from the readset so they can be validated
 	/// at commit in every isolation mode — even when the writeset is
@@ -485,8 +488,9 @@ pub(crate) struct TransactionInner {
 	/// validated: locking a key never widens the abort surface of the
 	/// transaction's other reads
 	pub(crate) lockset: HashSet<Bytes>,
-	/// Bloom filter over the lockset for fast conflict pre-checks
-	pub(crate) lockset_bloom: Mutex<BloomFilter>,
+	/// Bloom filter over the lockset for fast conflict pre-checks. Boxed
+	/// for the same reason as `readset_bloom`
+	pub(crate) lockset_bloom: Mutex<Box<BloomFilter>>,
 	/// The local set of key scans
 	pub(crate) scanset: SkipMap<Bytes, ArcSwap<Bytes>>,
 	/// The local set of updates and deletes
@@ -567,9 +571,9 @@ impl TransactionInner {
 			version,
 			locked: false,
 			readset: HashSet::new(),
-			readset_bloom: Mutex::new(BloomFilter::new()),
+			readset_bloom: Mutex::new(Box::new(BloomFilter::new())),
 			lockset: HashSet::new(),
-			lockset_bloom: Mutex::new(BloomFilter::new()),
+			lockset_bloom: Mutex::new(Box::new(BloomFilter::new())),
 			scanset: SkipMap::new(),
 			writeset: BTreeMap::new(),
 			database: db,
@@ -596,10 +600,14 @@ impl TransactionInner {
 		self.readset.pin().clear();
 		// Clear the readset bloom filter
 		self.readset_bloom.lock().clear();
-		// Clear the transaction lockset
-		self.lockset.pin().clear();
-		// Clear the lockset bloom filter
-		self.lockset_bloom.lock().clear();
+		// Clear the transaction lockset. `locked` still describes the
+		// previous use of this pooled transaction here, so the clear is
+		// skipped for the transactions that never locked a key and whose
+		// lockset is therefore already empty
+		if self.locked {
+			self.lockset.pin().clear();
+			self.lockset_bloom.lock().clear();
+		}
 		// Clear or completely reset the allocated writeset
 		if self.writeset.len() > threshold {
 			self.writeset = BTreeMap::new();

--- a/tests/isolation.rs
+++ b/tests/isolation.rs
@@ -731,3 +731,43 @@ fn ssi_locked_read_does_not_arm_scan_validation() {
 	// tx1 must commit: no concurrent write touched the locked key
 	assert!(tx1.commit().is_ok(), "A locked read must not arm scan validation without writes");
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+#[test]
+fn locked_read_does_not_leak_into_a_pooled_reuse() {
+	let db = Database::new();
+
+	// Create initial data
+	let mut tx = db.transaction(true);
+	tx.set("key", "initial").unwrap();
+	tx.commit().unwrap();
+
+	// Lock a key, then drop the transaction without committing or
+	// cancelling it, so it goes back to the pool with a populated lockset
+	{
+		let mut tx1 = db.transaction(true);
+		assert_eq!(tx1.get_for_update("key").unwrap(), Some(Bytes::from("initial")));
+	}
+
+	// Take that pooled transaction back out. Its snapshot is established
+	// here, before the concurrent write below
+	let mut tx3 = db.transaction(true);
+
+	// A concurrent transaction writes the previously locked key, and
+	// commits after tx3's snapshot
+	let mut tx2 = db.transaction(true);
+	tx2.set("key", "modified").unwrap();
+	assert!(tx2.commit().is_ok());
+
+	// tx3 locks a different key, arming lockset validation for itself
+	assert_eq!(tx3.get_for_update("other").unwrap(), None);
+
+	// tx3 must commit: it never locked "key", so the write to it is not a
+	// conflict. Only a lockset left behind by the previous use of this
+	// pooled transaction could make this abort
+	let result = tx3.commit();
+	assert!(
+		result.is_ok(),
+		"A reused transaction must not inherit a stale lockset, got: {result:?}"
+	);
+}


### PR DESCRIPTION
## What

`Transaction` grew from 1408 to 2048 bytes in 0.25.0. The transaction pool stores `TransactionInner` **by value** in an `ArrayQueue`, so the whole struct is memcpy'd on every pool checkout and every release — twice per transaction. `BloomFilter` holds its 4096-bit array inline, so the `lockset_bloom` added by #92 put a second ~520 byte array directly on the pooled struct, on top of the `readset_bloom` that was already there.

This boxes both per-transaction filters so only a pointer rides on the struct, and gates the `reset()` lockset clear on `self.locked` — `clear_read_state()` already gates the same work, but `reset()` was memsetting 512 bytes and taking a papaya epoch pin on every checkout for state that only `get_for_update` ever populates.

`Commit::writeset_bloom` in `queue.rs` deliberately stays inline: those entries are read in the conflict-check loop and are not pooled by value, so boxing there would add an indirection for nothing.

The `Box` allocation happens once per pool slot, not once per transaction — pooled transactions retain it across `reset()`.

## Result

`Transaction` goes 2048 → **1024 bytes**, below the 1408 it was before #92.

Measured with a harness that depends on both crate versions in one binary and interleaves the suites, 300k iterations, release, five runs:

| vs 0.24.0 | begin+commit | begin+get+commit | begin+set+commit |
|---|---|---|---|
| 0.25.0 as published | +22 to +32% | +13 to +21% | +3 to +10% |
| this branch | **−14 to −18%** | **−7 to −8%** | roughly parity |

The write path is dominated by other work, so read that last column as "no longer regressed" rather than a win.

## Correctness

The `reset()` gate relies on `locked` still describing the *previous* use of a pooled transaction at that point, which is what makes the skip safe. `tests/isolation.rs` gains a regression test for it: lock a key, drop the transaction without committing so it returns to the pool with a populated lockset, take it back out, let a concurrent transaction write that key after the reused transaction's snapshot, then have the reused transaction lock a *different* key to arm its own validation. It must commit.

That test is mutation-verified — with the clear removed it fails with `KeyReadConflict`, and it does not fire without the second `get_for_update`, because a stale lockset is inert while `locked` is false.

Full suite (470 tests) passes, `cargo clippy --all-targets` clean.

## Follow-up, not in this PR

SurrealDB's `kvs-mem` calls `.with_snapshot_isolation()`, so the readset is never populated in its usage — yet `reset()` still clears the readset bloom unconditionally. That cost predates #92. Gating it needs a `tracked` bool set at the readset insert sites rather than a `self.mode` check, since `with_snapshot_isolation()` is a builder method that can legally be called after a read.